### PR TITLE
Update Red Team Operational Engagement Log

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -29,3 +29,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | Fri Jan 23 18:10:17 UTC 2026 | Code: KIL-AU | jules-1135861634417593190-ba3787c9 | PENDING | Updated Red Team Operational Engagement Log. | > - [INFO: SYSTEM STABLE] | D728BA0F |
 | Sat Jan 24 18:23:05 UTC 2026 | Code: TUA-H | jules-10372684642245424697-ff3adf65 | PENDING | Updated Red Team Operational Engagement Log. | > - [INFO: SYSTEM STABLE] | 3C04C98A |
 | Mon Jan 26 18:04:01 UTC 2026 | Code: JUN-A | jules-3318738945310194034-680151c2 | PENDING | Updated Red Team Operational Engagement Log. | > - [INFO: SYSTEM STABLE] | CE65A27E |
+| Wed Jan 28 18:12:14 UTC 2026 | Code: KIL-AU | update-attendance-log | PENDING | Updated Red Team Operational Engagement Log. | > - [INFO: SYSTEM STABLE] | 55F89FE8 |


### PR DESCRIPTION
Appended a new log entry to `Attendance.md` as requested by the Clinical Red Team Security Auditor task.

---
*PR created automatically by Jules for task [5874279884394511079](https://jules.google.com/task/5874279884394511079) started by @AgentHitmanFaris*